### PR TITLE
Fix: Index out out range with empty parts []

### DIFF
--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -324,7 +324,7 @@ class BaseGenerateContentResponse:
             ValueError: If the candidate list or parts list does not contain exactly one entry.
         """
         parts = self.parts
-        if len(parts) > 1 or "text" not in parts[0]:
+        if len(parts) > 1 or not parts or "text" not in parts[0]:
             raise ValueError(
                 "The `response.text` quick accessor only works for "
                 "simple (single-`Part`) text responses. This response "


### PR DESCRIPTION
while question was blocked by api, the parts is an empty list [],  so the exp: 
if len(parts) > 1 or "text" not in parts[0]:
will raise list index out of range, but not ValueError

## Description of the change
<!--- Describe your changes in detail. -->
check the parts 
## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->

## Type of change
Choose one: (Bug fix | Feature request | Documentation | Other)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
